### PR TITLE
refinements

### DIFF
--- a/iotedgedev/iothub.py
+++ b/iotedgedev/iothub.py
@@ -15,7 +15,7 @@ class IoTHub:
         self.envvars.verify_envvar_has_val("IOTHUB_CONNECTION_STRING", self.envvars.IOTHUB_CONNECTION_STRING)
         self.envvars.verify_envvar_has_val("DEVICE_CONNECTION_STRING", self.envvars.DEVICE_CONNECTION_STRING)
 
-        if timeout == None:
+        if not timeout:
             timeout = 0
 
         self.output.header("MONITOR EVENTS")
@@ -42,4 +42,7 @@ class IoTHub:
             self.output.error(str(ex))
 
     def monitor_events_cli(self, timeout=0):
-        self.azure_cli.monitor_events(self.envvars.DEVICE_CONNECTION_INFO.DeviceId, self.envvars.IOTHUB_CONNECTION_INFO.ConnectionString, self.envvars.IOTHUB_CONNECTION_INFO.HubName, timeout)
+        self.azure_cli.monitor_events(self.envvars.DEVICE_CONNECTION_INFO.DeviceId,
+                                      self.envvars.IOTHUB_CONNECTION_INFO.ConnectionString,
+                                      self.envvars.IOTHUB_CONNECTION_INFO.HubName,
+                                      timeout)

--- a/tests/test_iotedgedev.py
+++ b/tests/test_iotedgedev.py
@@ -183,18 +183,17 @@ def test_monitor(request, capfd):
 
     cli = __import__("iotedgedev.cli", fromlist=['main'])
     runner = CliRunner()
-    result = runner.invoke(cli.main, ['monitor', '--timeout', '2'])
+    result = runner.invoke(cli.main, ['monitor', '--timeout', '5'])
     out, err = capfd.readouterr()
     print(out)
     print(err)
     print(result.output)
 
-    if PY35:
-        assert 'Starting event monitor' in out
-    else:
+    if not PY35:
         assert 'Monitoring events from device' in out
+    else:
+        assert not err
 
-    
 
 # @pytest.fixture
 # def test_stop(request):


### PR DESCRIPTION
* The solution is more complicated because subprocess does not support
timeout in py 2.7
* Test change to assert no errors from standard error
* The IoT extension monitor-events must return a non zero error code in case
of errors (to be adhered to in 0.5.2).